### PR TITLE
Fix clean build

### DIFF
--- a/pf_driver/CMakeLists.txt
+++ b/pf_driver/CMakeLists.txt
@@ -57,6 +57,7 @@ target_link_libraries(ros_main
   ${catkin_LIBRARIES} curlpp curl jsoncpp
 )
 add_dependencies(ros_main ${PROJECT_NAME}_gencfg)
+add_dependencies(ros_main ${${PROJECT_NAME}_EXPORTED_TARGETS})
 
 #if (CATKIN_ENABLE_TESTING)
 #  set(${PROJECT_NAME}_TEST_SOURCES


### PR DESCRIPTION
Missing dependencies caused fresh builds to fail because the message headers weren't generated until too late.