### PR TITLE
R2000 fix

### DIFF
--- a/pf_driver/include/pf_driver/pf/http_helpers.hpp
+++ b/pf_driver/include/pf_driver/pf/http_helpers.hpp
@@ -36,6 +36,7 @@
 #include <json/json.h>
 
 using param_type = std::pair<std::string, std::string>;
+using param_map_type = std::map<std::string, std::string>;
 
 inline std::string from_array(Json::Value &val)
 {
@@ -68,6 +69,16 @@ public:
     {
         url_ += "?"; 
         for (const auto &p : list)
+        {
+            url_ += p.first + "=" + p.second + "&";
+        }
+        url_.pop_back();
+    }
+
+    void append_query(const param_map_type &params, bool do_encoding = false)
+    {
+        url_ += "?";
+        for (const auto &p : params)
         {
             url_ += p.first + "=" + p.second + "&";
         }
@@ -111,7 +122,24 @@ public:
     res.append_path(base_path);
     res.append_path(command);
     res.append_query(list);
+    return get_(json_keys, res);
+  }
 
+  const std::map<std::string, std::string>
+  get(const std::vector<std::string> &json_keys, const std::string command,
+      const param_map_type &params = param_map_type())
+  {
+    CurlResource res(host);
+    res.append_path(base_path);
+    res.append_path(command);
+    res.append_query(params);
+    return get_(json_keys, res);
+  }
+
+private:
+  const std::map<std::string, std::string>
+  get_(const std::vector<std::string> &json_keys, CurlResource &res)
+  {
     Json::Value json_resp;
     std::map<std::string, std::string> json_kv;
 
@@ -149,7 +177,6 @@ public:
     return json_kv;
   }
 
-private:
   const std::string host;
   const std::string base_path;
 };

--- a/pf_driver/include/pf_driver/pf/pfsdp_protocol.hpp
+++ b/pf_driver/include/pf_driver/pf/pfsdp_protocol.hpp
@@ -351,11 +351,13 @@ public:
     return get_request_bool("reset_parameter", { "" }, { KV("list", ts...) });
   }
 
-  HandleInfo request_handle_tcp(const std::string port = "")
+  HandleInfo request_handle_tcp(const std::string port = "", const std::string packet_type = "")
   {
     param_map_type query;
     if(!port.empty())
       query["port"] = port;
+    if(!packet_type.empty())
+      query["packet_type"] = packet_type;
     auto resp = get_request("request_handle_tcp", { "handle", "port" }, query);
 
     HandleInfo handle_info;
@@ -365,9 +367,11 @@ public:
     return handle_info;
   }
 
-  virtual HandleInfo request_handle_udp(const std::string host_ip, const std::string port)
+  virtual HandleInfo request_handle_udp(const std::string host_ip, const std::string port, const std::string packet_type = "")
   {
     param_map_type query = { KV("address", host_ip), KV("port", port) };
+    if(!packet_type.empty())
+      query["packet_type"] = packet_type;
     auto resp = get_request("request_handle_udp", { "handle", "port" }, query);
 
     HandleInfo handle_info;

--- a/pf_driver/include/pf_driver/pf/pfsdp_protocol.hpp
+++ b/pf_driver/include/pf_driver/pf/pfsdp_protocol.hpp
@@ -187,8 +187,12 @@ private:
   std::string hostname;
 
   const std::map<std::string, std::string>
+  get_request(const std::string command, std::vector<std::string> json_keys, const std::initializer_list<param_type> query) {
+    return get_request(command, json_keys, param_map_type(query.begin(), query.end()));
+  }
+  const std::map<std::string, std::string>
   get_request(const std::string command, std::vector<std::string> json_keys = std::vector<std::string>(),
-              std::initializer_list<param_type> query = std::initializer_list<param_type>())
+              const param_map_type query = param_map_type())
   {
     const std::string err_code = "error_code";
     const std::string err_text = "error_text";
@@ -349,11 +353,10 @@ public:
 
   HandleInfo request_handle_tcp(const std::string port = "")
   {
-    std::map<std::string, std::string> resp;
+    param_map_type query;
     if(!port.empty())
-      resp = get_request("request_handle_tcp", { "handle", "port"}, { KV("port", port) });
-    else 
-      resp = get_request("request_handle_tcp", { "handle", "port"});
+      query["port"] = port;
+    auto resp = get_request("request_handle_tcp", { "handle", "port" }, query);
 
     HandleInfo handle_info;
     handle_info.hostname = hostname;
@@ -364,7 +367,9 @@ public:
 
   virtual HandleInfo request_handle_udp(const std::string host_ip, const std::string port)
   {
-    auto resp = get_request("request_handle_udp", { "handle", "port" }, { KV("address", host_ip), KV("port", port) });
+    param_map_type query = { KV("address", host_ip), KV("port", port) };
+    auto resp = get_request("request_handle_udp", { "handle", "port" }, query);
+
     HandleInfo handle_info;
     handle_info.handle = resp["handle"];
     handle_info.port = resp["port"];

--- a/pf_driver/src/pf/pf_interface.cpp
+++ b/pf_driver/src/pf/pf_interface.cpp
@@ -92,17 +92,12 @@ bool PFInterface::start_transmission()
     if(pipeline_ && pipeline_->is_running())
         return true;
 
+    std::string pkt_type = (expected_device_ == "R2000") ? "C" : "";
     if(transport_type_ == transport_type::tcp)
     {
+        info_ = protocol_interface_->request_handle_tcp(port_, pkt_type);
         if(port_.empty())
-        {
-            info_ = protocol_interface_->request_handle_tcp();
             port_ = info_.port;
-        }
-        else
-        {
-            info_ = protocol_interface_->request_handle_tcp(port_);
-        }
         transport_->set_port(port_);
         transport_->connect();
     }
@@ -113,7 +108,7 @@ bool PFInterface::start_transmission()
 
         std::string host_ip = transport_->get_host_ip();
         port_ = transport_->get_port();
-        info_ = protocol_interface_->request_handle_udp(host_ip, port_);
+        info_ = protocol_interface_->request_handle_udp(host_ip, port_, pkt_type);
     }
     if(info_.handle.empty())
         return false;
@@ -165,6 +160,7 @@ std::unique_ptr<Pipeline<PFPacket>> PFInterface::get_pipeline(std::string packet
     std::shared_ptr<Reader<PFPacket>> reader;
     if(product_ == "R2000")
     {
+        ROS_DEBUG("PacketType is: %s", packet_type.c_str());
         if(packet_type == "A")
         {
             parser = std::unique_ptr<Parser<PFPacket>>(new PFR2000_A_Parser);

--- a/pf_driver/src/pf/pf_packet.cpp
+++ b/pf_driver/src/pf/pf_packet.cpp
@@ -14,12 +14,9 @@ bool PFPacket::parse_buf(uint8_t* buf, size_t buf_len, size_t &remainder, size_t
     std::tie(h_size, p_size, num) = read_header(stream);
 
     auto data_size = p_size - h_size;
-    if((buf_len - SIZE) < data_size)
+    if(buf_len < p_size)
         return false;
     
-    if((num > (data_size / sizeof(uint32_t))) || (num == 0))
-        return false;
-
     read_data(&buf[h_size], num);
     remainder = buf_len - p_size;
     packet_size = p_size;

--- a/pf_driver/src/pf/pf_packet.cpp
+++ b/pf_driver/src/pf/pf_packet.cpp
@@ -66,11 +66,13 @@ void PFR2000Packet_B::read_with(PFPacketReader& reader)
 void PFR2000Packet_B::read_data(uint8_t *buf, size_t num)
 {
     Data *data = reinterpret_cast<Data*>(buf);
-    // for(int i = 0; i < num; i++)
-    // {
-    //     distance.push_back(data[i].distance);
-    //     amplitude.push_back(data[i].amplitude);
-    // }
+    distance.resize(num);
+    amplitude.resize(num);
+    for(int i = 0; i < num; i++)
+    {
+        distance[i] = data[i].distance;
+        amplitude[i] = data[i].amplitude;
+    }
 }
 
 void PFR2000Packet_C::read_with(PFPacketReader& reader)

--- a/pf_driver/src/pf/pf_packet.cpp
+++ b/pf_driver/src/pf/pf_packet.cpp
@@ -52,7 +52,6 @@ void PFR2000Packet_A::read_data(uint8_t *buf, size_t num)
 {
     Data *data = reinterpret_cast<Data*>(buf);
     distance.resize(num);
-    amplitude.resize(num);
     for(int i = 0; i < num; i++)
     {
         distance[i] = data[i].distance;

--- a/pf_driver/src/ros/scan_publisher.cpp
+++ b/pf_driver/src/ros/scan_publisher.cpp
@@ -64,6 +64,8 @@ void ScanPublisher::to_msg_queue(T &packet, uint16_t layer_idx)
         }
 
         msg->ranges.resize(packet.header.num_points_scan);
+        if(!packet.amplitude.empty())
+            msg->intensities.resize(packet.header.num_points_scan);
         d_queue_.push_back(msg);
     }
     msg = d_queue_.back();
@@ -83,6 +85,8 @@ void ScanPublisher::to_msg_queue(T &packet, uint16_t layer_idx)
         else
             data = packet.distance[i] / 1000.0;
         msg->ranges[idx + i] = std::move(data);
+        if(!packet.amplitude.empty() && packet.amplitude[i] >= 32)
+            msg->intensities[idx + i] = packet.amplitude[i];
     }
     if(packet.header.num_points_scan == (idx + packet.header.num_points_packet))
     {


### PR DESCRIPTION
Several fixes to get this working with the R2000 sensor I have (more details in individual commit messages):
- Actually publish amplitudes in the LaserScan messages
- Re-enable parsing of packet type B data
- Support non-default packet type and use packet type C instead of A on R2000 (no change to R2300)
- Fix/workaround for (I assume?) older lidar that's using a shorter packet header than the latest PFSDP spec
- Fix for streaming data over TCP (where one PFSDP packet != one TCP packet)
