### PR TITLE
Minor fixes for dynamic reconfigure on R2000

### DIFF
--- a/pf_driver/cfg/PFDriverR2000.cfg
+++ b/pf_driver/cfg/PFDriverR2000.cfg
@@ -18,8 +18,8 @@ gen_r2000.add("subnet_mask",          str_t,    3, "IP netmask", "255.0.0.0")
 gen_r2000.add("gateway",              str_t,    4, "IP gateway", "0.0.0.0")
 gen_r2000.add("scan_frequency",       int_t,    5, "The parameter scan_frequency defines the set point for the rotational speed of the sensor head and therefore the number of scans recorded per second. For the R2000 valid values range from 10 Hz to 50 Hz with steps of 1 Hz.", 35, 10, 50)
 
-scan_direction_enum = gen_r2000.enum([ gen_r2000.const("cw",  int_t, 0, "Clocl-wise"),
-                                       gen_r2000.const("ccw", int_t, 1, "Counter clock-wise")],
+scan_direction_enum = gen_r2000.enum([ gen_r2000.const("cw",  str_t, "cw", "Clock-wise"),
+                                       gen_r2000.const("ccw", str_t, "ccw", "Counter clock-wise")],
                                        "An enum to set scan direction")
 gen_r2000.add("scan_direction",        str_t,    6, "The parameter scan_direction defines the direction of rotation of the sensors head. User applications can choose between clockwise rotation (cw) or counter-clockwise rotation (ccw).", "ccw", edit_method=scan_direction_enum)
 
@@ -61,13 +61,13 @@ samples_per_scan_enum = gen_r2000.enum([ gen_r2000.const("samples_per_scan_72", 
 gen_r2000.add("samples_per_scan", int_t, 7, "The parameter samples_per_scan defines the number of samples recorded during one revolution of the sensor head (for details please refer to section 3.1 in the R2000 Ethernet communication protocol).", 3600, 72, 25200)
 
 hmi_display_mode_enum = gen_r2000.enum([ gen_r2000.const("hmi_display_off",  str_t, "off", ""),
-                                         gen_r2000.const("static_logo", str_t, "static logo", ""),
-                                         gen_r2000.const("statc_text", str_t, "statc text", ""),
-                                         gen_r2000.const("bargraph_distance", str_t, "bargraph distance", ""),
-                                         gen_r2000.const("bargraph_echo", str_t, "bargraph echo", ""),
-                                         gen_r2000.const("bargraph_reflector", str_t, "bargraph reflector", ""),
-                                         gen_r2000.const("application_bitmap", str_t, "application bitmap", ""),
-                                         gen_r2000.const("application_text", str_t, "application text", "")],
+                                         gen_r2000.const("static_logo", str_t, "static_logo", ""),
+                                         gen_r2000.const("static_text", str_t, "static_text", ""),
+                                         gen_r2000.const("bargraph_distance", str_t, "bargraph_distance", ""),
+                                         gen_r2000.const("bargraph_echo", str_t, "bargraph_echo", ""),
+                                         gen_r2000.const("bargraph_reflector", str_t, "bargraph_reflector", ""),
+                                         gen_r2000.const("application_bitmap", str_t, "application_bitmap", ""),
+                                         gen_r2000.const("application_text", str_t, "application_text", "")],
                                          "An enum to set hmi display mode")
 gen_r2000.add("hmi_display_mode", str_t, 8, "The parameter hmi_display_mode controls the content of the HMI LED display during normal operation, i.e. while neither warnings nor errors are displayed and the user did not activate the HMI menu.", "static_logo", edit_method=hmi_display_mode_enum)
 
@@ -107,7 +107,7 @@ packet_type_enum = gen_r2000.enum([ gen_r2000.const("packet_type_A", str_t, "A",
 gen_r2000.add("packet_type",          str_t,    18, "Packet type for scan data output", "A", edit_method=packet_type_enum)
 gen_r2000.add("packet_crc",           str_t,    19, "Append extra CRC32 for scan data integrity check")
 watchdog_enum = gen_r2000.enum([ gen_r2000.const("watchdog_on",     str_t, "on", "watchdog on"),
-                                 gen_r2000.const("watchdog_off", str_t, "emitter_off", "emitter_off mode")],
+                                 gen_r2000.const("watchdog_off", str_t, "off", "watchdog off")],
                                        "An enum to set operating mode")
 gen_r2000.add("watchdog",             str_t,    20, "Cease scan data output if watchdog isn't fed in time", "off", edit_method=watchdog_enum)
 gen_r2000.add("watchdogtimeout",      int_t,    21, "Maximum time for client to feed watchdog", 60000)

--- a/pf_driver/include/pf_driver/pf/pf_interface.h
+++ b/pf_driver/include/pf_driver/pf/pf_interface.h
@@ -30,8 +30,6 @@ public:
         }
         protocol_interface_ = std::make_shared<PFSDPBase>(ip_);
 
-        param_server_R2000_.setCallback(boost::bind(&PFInterface::reconfig_callback_r2000, this, boost::placeholders::_1, boost::placeholders::_2));
-        param_server_R2300_.setCallback(boost::bind(&PFInterface::reconfig_callback_r2300, this, boost::placeholders::_1, boost::placeholders::_2));
     }
 
     bool init();
@@ -48,8 +46,8 @@ private:
     std::unique_ptr<Transport> transport_;
     transport_type transport_type_;
     std::shared_ptr<PFSDPBase> protocol_interface_;
-    dynamic_reconfigure::Server<pf_driver::PFDriverR2000Config> param_server_R2000_;
-    dynamic_reconfigure::Server<pf_driver::PFDriverR2300Config> param_server_R2300_;
+    std::unique_ptr<dynamic_reconfigure::Server<pf_driver::PFDriverR2000Config> > param_server_R2000_;
+    std::unique_ptr<dynamic_reconfigure::Server<pf_driver::PFDriverR2300Config> > param_server_R2300_;
 
     enum class PFState
     {
@@ -70,6 +68,7 @@ private:
     void change_state(PFState state);
     bool can_change_state(PFState state);
     bool handle_version(int major_version, int minor_version);
+    void setup_param_server();
 
     void start_watchdog_timer(float duration);
     void feed_watchdog(const ros::TimerEvent& e);   //timer based

--- a/pf_driver/src/pf/pf_interface.cpp
+++ b/pf_driver/src/pf/pf_interface.cpp
@@ -17,6 +17,7 @@ bool PFInterface::init()
         return false;
     if(!handle_version(opi.version_major, opi.version_minor))
         return false;
+    setup_param_server();
 
     change_state(PFState::INIT);
     return true;
@@ -67,6 +68,20 @@ bool PFInterface::handle_version(int major_version, int minor_version)
     }
     ROS_ERROR("Device unsupported");
     return false;
+}
+
+void PFInterface::setup_param_server()
+{
+    if(expected_device_ == "R2000")
+    {
+        param_server_R2000_ = std::make_unique<dynamic_reconfigure::Server<pf_driver::PFDriverR2000Config> >();
+        param_server_R2000_->setCallback(boost::bind(&PFInterface::reconfig_callback_r2000, this, boost::placeholders::_1, boost::placeholders::_2));
+    }
+    else
+    {
+        param_server_R2300_ = std::make_unique<dynamic_reconfigure::Server<pf_driver::PFDriverR2300Config> >();
+        param_server_R2300_->setCallback(boost::bind(&PFInterface::reconfig_callback_r2300, this, boost::placeholders::_1, boost::placeholders::_2));
+    }
 }
 
 bool PFInterface::start_transmission()


### PR DESCRIPTION
- Fix conflict between dynamic reconfigure servers between R2000 and R2300
- Adjust some of the config enums for R2000 which were breaking the dynamic reconfigure GUI due to mismatches between enum values and defaults.