### PR TITLE
Dyn reconfig start angle max points scan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,15 @@ env:
   global:
     - CCACHE_DIR=$HOME/.ccache # enables C/C++ caching in industrial_ci
   matrix:
-    - ROS_DISTRO="melodic"
+    - ROS_DISTRO="melodic" CLANG_FORMAT_CHECK=file
+    - ROS_DISTRO="melodic" CATKIN_LINT=true
+    - ROS_DISTRO="melodic" ROS_REPO=main
+    - ROS_DISTRO="melodic" PRERELEASE=true
     - ROS_DISTRO="noetic"
-    - ROS_DISTRO="melodic" CLANG_FORMAT_CHECK=file CLANG_FORMAT_VERSION=3.9
+
+matrix:
+  allow_failures:
+    - env: ROS_DISTRO="indigo" PRERELEASE=true # need not pass for all PRs
 
 install:
   - git clone --quiet --depth 1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,17 @@ language: generic
 services:
   - docker
 
+cache:
+  directories:
+    - $HOME/.ccache
+
 env:
+  global:
+    - CCACHE_DIR=$HOME/.ccache # enables C/C++ caching in industrial_ci
   matrix:
     - ROS_DISTRO="melodic"
+    - ROS_DISTRO="noetic"
+    - ROS_DISTRO="melodic" CLANG_FORMAT_CHECK=file CLANG_FORMAT_VERSION=3.9
 
 install:
   - git clone --quiet --depth 1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci

--- a/pf_driver/include/pf_driver/pf/pf_interface.h
+++ b/pf_driver/include/pf_driver/pf/pf_interface.h
@@ -32,7 +32,7 @@ public:
   }
 
   bool init();
-  bool start_transmission();
+  bool start_transmission(ScanConfig& config);
   void stop_transmission();
   void terminate();
 

--- a/pf_driver/include/pf_driver/pf/pfsdp_protocol.hpp
+++ b/pf_driver/include/pf_driver/pf/pfsdp_protocol.hpp
@@ -396,11 +396,17 @@ public:
     config.max_num_points_scan = to_long(resp["max_num_points_scan"]);
     return config;
   }
-  
+
   bool set_scanoutput_config(std::string handle, ScanConfig config)
   {
-    param_map_type query = { KV("handle", handle), KV("start_angle", config.start_angle), KV("max_num_points_scan",config.max_num_points_scan) };
-    auto resp = get_request("set_scanoutput_config", {""},query );
+    param_map_type query = { KV("handle", handle),
+                             KV("start_angle", config.start_angle),
+                             KV("packet_type", config.max_num_points_scan),
+                             KV("max_num_points_scan", config.packet_type),
+                             KV("watchdogtimeout", config.watchdogtimeout),
+                             KV("skip_scans", config.skip_scans),
+                             KV("watchdog", config.watchdog) };
+    auto resp = get_request("set_scanoutput_config", { "" }, query);
     return true;
   }
   bool start_scanoutput(std::string handle)

--- a/pf_driver/include/pf_driver/pf/pfsdp_protocol.hpp
+++ b/pf_driver/include/pf_driver/pf/pfsdp_protocol.hpp
@@ -396,7 +396,13 @@ public:
     config.max_num_points_scan = to_long(resp["max_num_points_scan"]);
     return config;
   }
-
+  
+  bool set_scanoutput_config(std::string handle, ScanConfig config)
+  {
+    param_map_type query = { KV("handle", handle), KV("start_angle", config.start_angle), KV("max_num_points_scan",config.max_num_points_scan) };
+    auto resp = get_request("set_scanoutput_config", {""},query );
+    return true;
+  }
   bool start_scanoutput(std::string handle)
   {
     get_request("start_scanoutput", { "" }, { { "handle", handle } });

--- a/pf_driver/include/pf_driver/pf/pfsdp_protocol.hpp
+++ b/pf_driver/include/pf_driver/pf/pfsdp_protocol.hpp
@@ -384,12 +384,16 @@ public:
 
   virtual ScanConfig get_scanoutput_config(std::string handle)
   {
-    auto resp = get_request("get_scanoutput_config", {"start_angle", "packet_type", "watchdogtimeout", "skip_scans", "watchdog"}, { KV("handle", handle) });
+    auto resp = get_request(
+        "get_scanoutput_config",
+        { "start_angle", "packet_type", "watchdogtimeout", "skip_scans", "watchdog", "max_num_points_scan" },
+        { KV("handle", handle) });
     config.packet_type = resp["packet_type"];
     config.start_angle = to_long(resp["start_angle"]);
     config.watchdogtimeout = to_long(resp["watchdogtimeout"]);
     config.watchdog = (resp["watchdog"] == "off") ? false : true;
     config.skip_scans = to_long(resp["skip_scans"]);
+    config.max_num_points_scan = to_long(resp["max_num_points_scan"]);
     return config;
   }
 

--- a/pf_driver/launch/r2000.launch
+++ b/pf_driver/launch/r2000.launch
@@ -3,9 +3,18 @@
   <arg name="transport" default="udp"/>
   <arg name="scanner_ip" default="169.254.253.4"/>
   <arg name="device" default="R2000"/>
+  <arg name="start_angle" default="-180"/>
+  <arg name="max_num_points_scan" default="0"/>
 
   <!-- R2000 Driver -->
-  <node pkg="pf_driver" type="ros_main" name="r2000_node" args="$(arg transport) $(arg scanner_ip) 0 $(arg device)" output="screen"/>
+  <node pkg="pf_driver" type="ros_main" name="r2000_node" output="screen">
+    <param name="transport" type="string" value="$(arg transport)">
+    <param name="scanner_ip" type="string" value="$(arg scanner_ip)">
+    <param name="port" type="string" value="0">
+    <param name="device" type="string" value="$(arg device)">
+    <param name="start_angle" type="int" value="$(arg start_angle)">
+    <param name="max_num_points_scan" type="int" value="$(arg max_num_points_scan)">
+  </node>
 
   <node pkg="tf" type="static_transform_publisher" name="static_transform_publisher" args="0 0 0 0 0 0 1 /base_link /scanner 100"/>
   <node type="rviz" name="rviz" pkg="rviz" args="-d $(find pf_driver)/rviz/r2000.rviz" />

--- a/pf_driver/launch/r2000.launch
+++ b/pf_driver/launch/r2000.launch
@@ -8,12 +8,12 @@
 
   <!-- R2000 Driver -->
   <node pkg="pf_driver" type="ros_main" name="r2000_node" output="screen">
-    <param name="transport" type="string" value="$(arg transport)">
-    <param name="scanner_ip" type="string" value="$(arg scanner_ip)">
-    <param name="port" type="string" value="0">
-    <param name="device" type="string" value="$(arg device)">
-    <param name="start_angle" type="int" value="$(arg start_angle)">
-    <param name="max_num_points_scan" type="int" value="$(arg max_num_points_scan)">
+    <param name="transport" type="string" value="$(arg transport)"/>
+    <param name="scanner_ip" type="string" value="$(arg scanner_ip)"/>
+    <param name="port" type="string" value="0"/>
+    <param name="device" type="string" value="$(arg device)"/>
+    <param name="start_angle" type="int" value="$(arg start_angle)"/>
+    <param name="max_num_points_scan" type="int" value="$(arg max_num_points_scan)"/>
   </node>
 
   <node pkg="tf" type="static_transform_publisher" name="static_transform_publisher" args="0 0 0 0 0 0 1 /base_link /scanner 100"/>

--- a/pf_driver/launch/r2300.launch
+++ b/pf_driver/launch/r2300.launch
@@ -8,12 +8,12 @@
 
   <!-- R2300 Driver -->
   <node pkg="pf_driver" type="ros_main" name="r2000_node" output="screen">
-    <param name="transport" type="string" value="$(arg transport)">
-    <param name="scanner_ip" type="string" value="$(arg scanner_ip)">
-    <param name="port" type="string" value="0">
-    <param name="device" type="string" value="$(arg device)">
-    <param name="start_angle" type="int" value="$(arg start_angle)">
-    <param name="max_num_points_scan" type="int" value="$(arg max_num_points_scan)">
+    <param name="transport" type="string" value="$(arg transport)"/>
+    <param name="scanner_ip" type="string" value="$(arg scanner_ip)"/>
+    <param name="port" type="string" value="0"/>
+    <param name="device" type="string" value="$(arg device)"/>
+    <param name="start_angle" type="int" value="$(arg start_angle)"/>
+    <param name="max_num_points_scan" type="int" value="$(arg max_num_points_scan)"/>
   </node>
 
   <node pkg="tf" type="static_transform_publisher" name="ring1" args="0 0 0 0 0.0785 0 /base_link /scanner_1 10" />

--- a/pf_driver/launch/r2300.launch
+++ b/pf_driver/launch/r2300.launch
@@ -3,9 +3,18 @@
   <arg name="transport" default="udp"/>
   <arg name="scanner_ip" default="10.0.10.76"/>
   <arg name="device" default="R2300"/>
+  <arg name="start_angle" default="-180"/>
+  <arg name="max_num_points_scan" default="0"/>
 
-  <!-- R2000 Driver -->
-  <node pkg="pf_driver" type="ros_main" name="r2300_node" args="$(arg transport) $(arg scanner_ip) 0 $(arg device)" output="screen"/>
+  <!-- R2300 Driver -->
+  <node pkg="pf_driver" type="ros_main" name="r2000_node" output="screen">
+    <param name="transport" type="string" value="$(arg transport)">
+    <param name="scanner_ip" type="string" value="$(arg scanner_ip)">
+    <param name="port" type="string" value="0">
+    <param name="device" type="string" value="$(arg device)">
+    <param name="start_angle" type="int" value="$(arg start_angle)">
+    <param name="max_num_points_scan" type="int" value="$(arg max_num_points_scan)">
+  </node>
 
   <node pkg="tf" type="static_transform_publisher" name="ring1" args="0 0 0 0 0.0785 0 /base_link /scanner_1 10" />
 	<node pkg="tf" type="static_transform_publisher" name="ring2" args="0 0 0 0 0.0262 0 /base_link /scanner_2 10" />

--- a/pf_driver/src/communication.cpp
+++ b/pf_driver/src/communication.cpp
@@ -63,6 +63,7 @@ bool UDPTransport::disconnect()
 {
   std::cout << "disconnecting..." << std::endl;
   socket_->close();
+  return true;
 }
 
 bool UDPTransport::read(boost::array<uint8_t, 4096>& buf, size_t& len)

--- a/pf_driver/src/pf/pf_interface.cpp
+++ b/pf_driver/src/pf/pf_interface.cpp
@@ -267,7 +267,7 @@ void PFInterface::reconfig_callback_r2000(pf_driver::PFDriverR2000Config& config
     protocol_interface_->handle_reconfig(config, level);
   }
   pipeline_->set_scanoutput_config(config_);
-  config_ = protocol_interface_->get_scanoutput_config(info_.handle);
+  protocol_interface_->set_scanoutput_config(info_.handle, config_);
   params_ = protocol_interface_->get_scan_parameters(config_.start_angle);
   pipeline_->set_scan_params(params_);
 }
@@ -319,8 +319,7 @@ void PFInterface::reconfig_callback_r2300(pf_driver::PFDriverR2300Config& config
     protocol_interface_->handle_reconfig(config, level);
   }
   pipeline_->set_scanoutput_config(config_);
+  protocol_interface_->set_scanoutput_config(info_.handle, config_);
   params_ = protocol_interface_->get_scan_parameters(config_.start_angle);
   pipeline_->set_scan_params(params_);
-    protocol_interface_->set_scanoutput_config(info_.handle,config_);
-    config_ = protocol_interface_->get_scanoutput_config(info_.handle);
 }

--- a/pf_driver/src/pf/pf_interface.cpp
+++ b/pf_driver/src/pf/pf_interface.cpp
@@ -274,46 +274,53 @@ void PFInterface::reconfig_callback_r2000(pf_driver::PFDriverR2000Config& config
 
 void PFInterface::reconfig_callback_r2300(pf_driver::PFDriverR2300Config& config, uint32_t level)
 {
-    if(product_ != "R2300")
-        return;
-    if(state_ != PFState::RUNNING)
-        return;
-    // Do we want to change the address and port at run-time?
-    // if(level == 16){
-    //   set_parameter({ KV("address", config.address) });
-    // } else if(level == 17)
-    // {
-    //   set_parameter({ KV("port", config.port) });
-    // }
-    if(level == 18)
-    {
-        config_.packet_type = config.packet_type;
-    } else if(level == 19)
-    {
-        // currently always none for R2300
-        // config_.packet_crc = config.packet_crc;
-    } else if(level == 20)
-    {
-        config_.watchdog = (config.watchdog == "on") ? true : false;
-    } else if(level == 21)
-    {
-        config_.watchdogtimeout = config.watchdogtimeout;
-    } else if(level == 22)
-    {
-        config_.start_angle = config.start_angle;
-    } else if(level == 23)
-    {
-        config_.max_num_points_scan = config.max_num_points_scan;
-    } else if(level == 24)
-    {
-        config_.skip_scans = config.skip_scans;
-    } else
-    {
-        protocol_interface_->handle_reconfig(config, level);
-    }
-    pipeline_->set_scanoutput_config(config_);
+  if (product_ != "R2300")
+    return;
+  if (state_ != PFState::RUNNING)
+    return;
+  // Do we want to change the address and port at run-time?
+  // if(level == 16){
+  //   set_parameter({ KV("address", config.address) });
+  // } else if(level == 17)
+  // {
+  //   set_parameter({ KV("port", config.port) });
+  // }
+  if (level == 18)
+  {
+    config_.packet_type = config.packet_type;
+  }
+  else if (level == 19)
+  {
+    // currently always none for R2300
+    // config_.packet_crc = config.packet_crc;
+  }
+  else if (level == 20)
+  {
+    config_.watchdog = (config.watchdog == "on") ? true : false;
+  }
+  else if (level == 21)
+  {
+    config_.watchdogtimeout = config.watchdogtimeout;
+  }
+  else if (level == 22)
+  {
+    config_.start_angle = config.start_angle;
+  }
+  else if (level == 23)
+  {
+    config_.max_num_points_scan = config.max_num_points_scan;
+  }
+  else if (level == 24)
+  {
+    config_.skip_scans = config.skip_scans;
+  }
+  else
+  {
+    protocol_interface_->handle_reconfig(config, level);
+  }
+  pipeline_->set_scanoutput_config(config_);
+  params_ = protocol_interface_->get_scan_parameters(config_.start_angle);
+  pipeline_->set_scan_params(params_);
     protocol_interface_->set_scanoutput_config(info_.handle,config_);
     config_ = protocol_interface_->get_scanoutput_config(info_.handle);
-    params_ = protocol_interface_->get_scan_parameters(config_.start_angle);
-    pipeline_->set_scan_params(params_);
 }

--- a/pf_driver/src/pf/pf_interface.cpp
+++ b/pf_driver/src/pf/pf_interface.cpp
@@ -90,7 +90,7 @@ void PFInterface::setup_param_server()
   }
 }
 
-bool PFInterface::start_transmission()
+bool PFInterface::start_transmission(ScanConfig& config)
 {
   if (state_ != PFState::INIT)
     return false;
@@ -120,6 +120,8 @@ bool PFInterface::start_transmission()
     return false;
 
   config_ = protocol_interface_->get_scanoutput_config(info_.handle);
+  config_.start_angle = config.start_angle;
+  config_.max_num_points_scan = config.max_num_points_scan;
   params_ = protocol_interface_->get_scan_parameters(config_.start_angle);
 
   // config_.print();

--- a/pf_driver/src/pf/pf_interface.cpp
+++ b/pf_driver/src/pf/pf_interface.cpp
@@ -274,52 +274,46 @@ void PFInterface::reconfig_callback_r2000(pf_driver::PFDriverR2000Config& config
 
 void PFInterface::reconfig_callback_r2300(pf_driver::PFDriverR2300Config& config, uint32_t level)
 {
-  if (product_ != "R2300")
-    return;
-  if (state_ != PFState::RUNNING)
-    return;
-  // Do we want to change the address and port at run-time?
-  // if(level == 16){
-  //   set_parameter({ KV("address", config.address) });
-  // } else if(level == 17)
-  // {
-  //   set_parameter({ KV("port", config.port) });
-  // }
-  if (level == 18)
-  {
-    config_.packet_type = config.packet_type;
-  }
-  else if (level == 19)
-  {
-    // currently always none for R2300
-    // config_.packet_crc = config.packet_crc;
-  }
-  else if (level == 20)
-  {
-    config_.watchdog = (config.watchdog == "on") ? true : false;
-  }
-  else if (level == 21)
-  {
-    config_.watchdogtimeout = config.watchdogtimeout;
-  }
-  else if (level == 22)
-  {
-    config_.start_angle = config.start_angle;
-  }
-  else if (level == 23)
-  {
-    config_.max_num_points_scan = config.max_num_points_scan;
-  }
-  else if (level == 24)
-  {
-    config_.skip_scans = config.skip_scans;
-  }
-  else
-  {
-    protocol_interface_->handle_reconfig(config, level);
-  }
-  pipeline_->set_scanoutput_config(config_);
-  config_ = protocol_interface_->get_scanoutput_config(info_.handle);
-  params_ = protocol_interface_->get_scan_parameters(config_.start_angle);
-  pipeline_->set_scan_params(params_);
+    if(product_ != "R2300")
+        return;
+    if(state_ != PFState::RUNNING)
+        return;
+    // Do we want to change the address and port at run-time?
+    // if(level == 16){
+    //   set_parameter({ KV("address", config.address) });
+    // } else if(level == 17)
+    // {
+    //   set_parameter({ KV("port", config.port) });
+    // }
+    if(level == 18)
+    {
+        config_.packet_type = config.packet_type;
+    } else if(level == 19)
+    {
+        // currently always none for R2300
+        // config_.packet_crc = config.packet_crc;
+    } else if(level == 20)
+    {
+        config_.watchdog = (config.watchdog == "on") ? true : false;
+    } else if(level == 21)
+    {
+        config_.watchdogtimeout = config.watchdogtimeout;
+    } else if(level == 22)
+    {
+        config_.start_angle = config.start_angle;
+    } else if(level == 23)
+    {
+        config_.max_num_points_scan = config.max_num_points_scan;
+    } else if(level == 24)
+    {
+        config_.skip_scans = config.skip_scans;
+    } else
+    {
+        protocol_interface_->handle_reconfig(config, level);
+    }
+    pipeline_->set_scanoutput_config(config_);
+    protocol_interface_->set_scanoutput_config(info_.handle,config_);
+    config_ = protocol_interface_->get_scanoutput_config(info_.handle);
+    params_ = protocol_interface_->get_scan_parameters(config_.start_angle);
+    pipeline_->set_scan_params(params_);
 }


### PR DESCRIPTION
For https://github.com/PepperlFuchs/ROS_driver/issues/35#issuecomment-754384255

In the current code, the dynamic reconfiguration for start_angle & max_num_points_scan has no effect because these changes are not communicated to R2300 by `set_scanoutput_config`.

This commit has been tested for R2300 only, and no changes have been made for R2000.