### PR TITLE
Rviz start angle max num points scan

### DIFF
--- a/pf_driver/include/pf_driver/pf/pfsdp_protocol.hpp
+++ b/pf_driver/include/pf_driver/pf/pfsdp_protocol.hpp
@@ -73,7 +73,7 @@ struct ScanParameters
   double angle_min = 0.0;
   double angle_max = 0.0;
   uint16_t layers_enabled = 0;
-  double scan_freq = 0.0; //needed to calculate scan resolution in R2300
+  double scan_freq = 0.0;  // needed to calculate scan resolution in R2300
 
   // void print()
   // {

--- a/pf_driver/include/pf_driver/pf/pfsdp_protocol.hpp
+++ b/pf_driver/include/pf_driver/pf/pfsdp_protocol.hpp
@@ -73,6 +73,7 @@ struct ScanParameters
   double angle_min = 0.0;
   double angle_max = 0.0;
   uint16_t layers_enabled = 0;
+  double scan_freq = 0.0; //needed to calculate scan resolution in R2300
 
   // void print()
   // {

--- a/pf_driver/include/pf_driver/pf/r2000/pfsdp_2000.hpp
+++ b/pf_driver/include/pf_driver/pf/r2000/pfsdp_2000.hpp
@@ -16,13 +16,14 @@ public:
 
   virtual ScanParameters get_scan_parameters(int start_angle)
   {
-    auto resp = get_parameter("angular_fov", "radial_range_min", "radial_range_max");
+    auto resp = get_parameter("angular_fov", "radial_range_min", "radial_range_max", "scan_frequency");
     params.angular_fov = to_float(resp["angular_fov"]) * M_PI / 180.0;
     params.radial_range_max = to_float(resp["radial_range_max"]);
     params.radial_range_min = to_float(resp["radial_range_min"]);
 
     params.angle_min = start_angle / 10000.0f * M_PI / 180.0;
     params.angle_max = params.angle_min + params.angular_fov;
+    params.scan_freq = to_float(resp["scan_frequency"]);
     return params;
   }
 

--- a/pf_driver/include/pf_driver/pf/r2300/pfsdp_2300.hpp
+++ b/pf_driver/include/pf_driver/pf/r2300/pfsdp_2300.hpp
@@ -17,7 +17,7 @@ public:
   virtual ScanParameters get_scan_parameters(int start_angle)
   {
     auto resp = get_parameter("angular_fov", "radial_range_min", "radial_range_max", "measure_start_angle",
-                              "measure_stop_angle");
+                              "measure_stop_angle", "scan_frequency");
     params.angular_fov = to_float(resp["angular_fov"]) * M_PI / 180.0;
     params.radial_range_max = to_float(resp["radial_range_max"]);
     params.radial_range_min = to_float(resp["radial_range_min"]);
@@ -26,6 +26,7 @@ public:
     params.angle_min = start_stop.first;
     params.angle_max = start_stop.second;
     get_layers_enabled(params.layers_enabled);
+    params.scan_freq = to_float(resp["scan_frequency"]);
     return params;
   }
 

--- a/pf_driver/src/ros/scan_publisher.cpp
+++ b/pf_driver/src/ros/scan_publisher.cpp
@@ -62,6 +62,23 @@ void ScanPublisher::to_msg_queue(T& packet, uint16_t layer_idx)
       msg->time_increment = (params_.angular_fov * msg->scan_time) / (M_PI * 2.0) / packet.header.num_points_scan;
       msg->angle_min = params_.angle_min;
       msg->angle_max = params_.angle_max;
+      if (std::is_same<T, PFR2300Packet_C1>::value)  // Only Packet C1 for R2300
+      {
+        double config_start_angle = config_.start_angle / 1800000.0 * M_PI;
+        if (config_start_angle > params_.angle_min)
+        {
+          msg->angle_min = config_start_angle;
+        }
+        if (config_.max_num_points_scan != 0)  // means need to calculate
+        {
+          double config_angle = (config_.max_num_points_scan - 1) * (params_.scan_freq / 500.0) / 180.0 * M_PI;
+          if (msg->angle_min + config_angle < msg->angle_max)
+          {
+            msg->angle_max = msg->angle_min + config_angle;
+          }
+        }
+      }
+
       msg->range_min = params_.radial_range_min;
       msg->range_max = params_.radial_range_max;
     }
@@ -75,30 +92,48 @@ void ScanPublisher::to_msg_queue(T& packet, uint16_t layer_idx)
   if (!msg)
     return;
 
-  // errors in scan_number - not in sequence sometimes
-  if (msg->header.seq != packet.header.header.scan_number)
-    return;
-  int idx = packet.header.first_index;
+  {
+    std::lock_guard<std::mutex> lock(config_mutex_);
+    msg->time_increment = (params_.angular_fov * msg->scan_time) / (M_PI * 2.0) / packet.header.num_points_scan;
+    msg->angle_min = params_.angle_min;
+    msg->angle_max = params_.angle_max;
+    msg->range_min = params_.radial_range_min;
+    msg->range_max = params_.radial_range_max;
+  }
 
-  for (int i = 0; i < packet.header.num_points_packet; i++)
+  msg->ranges.resize(packet.header.num_points_scan);
+  if (!packet.amplitude.empty())
+    msg->intensities.resize(packet.header.num_points_scan);
+  d_queue_.push_back(msg);
+}
+msg = d_queue_.back();
+if (!msg)
+  return;
+
+// errors in scan_number - not in sequence sometimes
+if (msg->header.seq != packet.header.header.scan_number)
+  return;
+int idx = packet.header.first_index;
+
+for (int i = 0; i < packet.header.num_points_packet; i++)
+{
+  float data;
+  if (packet.distance[i] == 0xFFFFFFFF)
+    data = std::numeric_limits<std::uint32_t>::quiet_NaN();
+  else
+    data = packet.distance[i] / 1000.0;
+  msg->ranges[idx + i] = std::move(data);
+  if (!packet.amplitude.empty() && packet.amplitude[i] >= 32)
+    msg->intensities[idx + i] = packet.amplitude[i];
+}
+if (packet.header.num_points_scan == (idx + packet.header.num_points_packet))
+{
+  if (msg)
   {
-    float data;
-    if (packet.distance[i] == 0xFFFFFFFF)
-      data = std::numeric_limits<std::uint32_t>::quiet_NaN();
-    else
-      data = packet.distance[i] / 1000.0;
-    msg->ranges[idx + i] = std::move(data);
-    if (!packet.amplitude.empty() && packet.amplitude[i] >= 32)
-      msg->intensities[idx + i] = packet.amplitude[i];
+    handle_scan(msg, layer_idx);
+    d_queue_.pop_back();
   }
-  if (packet.header.num_points_scan == (idx + packet.header.num_points_packet))
-  {
-    if (msg)
-    {
-      handle_scan(msg, layer_idx);
-      d_queue_.pop_back();
-    }
-  }
+}
 }
 
 // check the status bits here with a switch-case


### PR DESCRIPTION
This PR corrects a bug in RViz display when start_angle & max_num_points_scan is specified as reported in issue https://github.com/PepperlFuchs/ROS_driver/issues/47

When applied together with PR https://github.com/PepperlFuchs/ROS_driver/pull/49, dynamic reconfigure will work with the correct RViz display

Only code pertaining to R2300 is changed, as I don't have an R2000 to test with.