### PR TITLE
Fix UHD performance issue at frequencies higher than 30Hz

### DIFF
--- a/pf_driver/include/pf_driver/pf/pipeline.h
+++ b/pf_driver/include/pf_driver/pf/pipeline.h
@@ -136,7 +136,6 @@ private:
           ROS_DEBUG("Queue overflow!");
       }
       packets.clear();
-      std::this_thread::sleep_for(std::chrono::milliseconds(2));
     }
     writer_->stop();
     reader_->stop();


### PR DESCRIPTION
causes publish freq to drop at higher scan frequencies and max samples per scan