### PR TITLE
release handle doesn't get called 

### DIFF
--- a/src/pf_driver/src/pf/pf_interface.cpp
+++ b/src/pf_driver/src/pf/pf_interface.cpp
@@ -153,6 +153,7 @@ void PFInterface::stop_transmission()
     return;
   protocol_interface_->stop_scanoutput(info_->handle);
   protocol_interface_->release_handle(info_->handle);
+
   change_state(PFState::INIT);
 }
 
@@ -162,8 +163,6 @@ void PFInterface::terminate()
     return;
   watchdog_timer_.stop();
   pipeline_->terminate();
-
-  stop_transmission();
 
   pipeline_.reset();
   protocol_interface_.reset();

--- a/src/pf_driver/src/pf/pf_interface.cpp
+++ b/src/pf_driver/src/pf/pf_interface.cpp
@@ -162,6 +162,9 @@ void PFInterface::terminate()
     return;
   watchdog_timer_.stop();
   pipeline_->terminate();
+
+  stop_transmission();
+
   pipeline_.reset();
   protocol_interface_.reset();
   transport_.reset();

--- a/src/pf_driver/src/ros/ros_main.cpp
+++ b/src/pf_driver/src/ros/ros_main.cpp
@@ -102,6 +102,5 @@ int main(int argc, char* argv[])
     pf_interface.terminate();
   }
 
-  pf_interface.stop_transmission();
   return 0;
 }

--- a/src/pf_driver/src/ros/ros_main.cpp
+++ b/src/pf_driver/src/ros/ros_main.cpp
@@ -98,6 +98,9 @@ int main(int argc, char* argv[])
       {
         ROS_ERROR("Network failure");
       }
+      else{
+        pf_interface.stop_transmission();
+      }
     }
     pf_interface.terminate();
   }

--- a/src/pf_driver/src/ros/ros_main.cpp
+++ b/src/pf_driver/src/ros/ros_main.cpp
@@ -98,7 +98,8 @@ int main(int argc, char* argv[])
       {
         ROS_ERROR("Network failure");
       }
-      else{
+      else
+      {
         pf_interface.stop_transmission();
       }
     }


### PR DESCRIPTION
because the state is already changed to uninitialized. Refer https://github.com/PepperlFuchs/pf_lidar_ros_driver/issues/119