### PR TITLE
use port declared in configuration to establish connection

### DIFF
--- a/src/pf_driver/src/pf/pfsdp_base.cpp
+++ b/src/pf_driver/src/pf/pfsdp_base.cpp
@@ -186,6 +186,14 @@ void PFSDPBase::request_handle_tcp(const std::string& port, const std::string& p
   {
     query["packet_type"] = config_->packet_type;
   }
+  if (!port.empty())
+  {
+    query["port"] = port;
+  }
+  else
+  {
+    query["port"] = info_->port;
+  }
   auto resp = get_request("request_handle_tcp", { "handle", "port" }, query);
 
   info_->handle = resp["handle"];

--- a/src/pf_driver/src/pf/pfsdp_base.cpp
+++ b/src/pf_driver/src/pf/pfsdp_base.cpp
@@ -190,7 +190,7 @@ void PFSDPBase::request_handle_tcp(const std::string& port, const std::string& p
   {
     query["port"] = port;
   }
-  else
+  else if (info_->port.compare("0") != 0)
   {
     query["port"] = info_->port;
   }


### PR DESCRIPTION
r2000_params.yaml:
```
...
    port: 30300
...
```

ROS log:
```
ubuntu@ubuntu:~/ros1/nov23_01$ roslaunch pf_driver r2000.launch 
... logging to /home/ubuntu/.ros/log/ee0ea99a-8aa3-11ee-bf78-ef57b296b95b/roslaunch-ubuntu-3685.log
Checking log directory for disk usage. This may take a while.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.

started roslaunch server http://ubuntu:35363/

SUMMARY
========

PARAMETERS
 * /r2000_node/R2000/device: R2000
 * /r2000_node/R2000/frame_id: scanner_link
 * /r2000_node/R2000/max_num_points_scan: 0
 * /r2000_node/R2000/packet_type: A
 *** /r2000_node/R2000/port: 30300**
 * /r2000_node/R2000/scan_topic: /scan
 * /r2000_node/R2000/scanner_ip: 169.254.0.103
 * /r2000_node/R2000/start_angle: 0
 * /r2000_node/R2000/transport: tcp
 * /r2000_node/R2000/watchdog: True
 * /r2000_node/R2000/watchdogtimeout: 60000
 * /r2000_node/device: R2000
 * /robot_description: <?xml version="1....
 * /rosdistro: noetic
 * /rosversion: 1.16.0

NODES
  /
    r2000_node (pf_driver/ros_main)
    robot_state_publisher (robot_state_publisher/robot_state_publisher)
    rviz (rviz/rviz)

auto-starting new master
process[master]: started with pid [3705]
ROS_MASTER_URI=http://localhost:11311

setting /run_id to ee0ea99a-8aa3-11ee-bf78-ef57b296b95b
process[rosout-1]: started with pid [3716]
started core service [/rosout]
process[robot_state_publisher-2]: started with pid [3719]
process[r2000_node-3]: started with pid [3720]
process[rviz-4]: started with pid [3721]
[ INFO] [1700814725.979049255]: Device found: R2000
[ INFO] [1700814726.070794522]: Device state changed to Initialized
[ INFO] [1700814726.080480640]: Device state changed to Running
```
TCP dump (port = 60624):
```
09:33:23.414308 IP ubuntu.local.60300 > 169.254.0.103.60624: Flags [.], ack 41418752, win 2652, options [nop,nop,TS val 1734118787 ecr 340337], length 0
09:33:23.416639 IP 169.254.0.103.60624 > ubuntu.local.60300: Flags [.], seq 41418752:41420200, ack 1, win 2896, options [nop,nop,TS val 340338 ecr 1734118787], length 1448
```